### PR TITLE
Search Deployment, SP1 | Solr-Unsupported | LRDOCS-7272

### DIFF
--- a/en/deployment/articles/03-installing-a-search-engine/01-intro.markdown
+++ b/en/deployment/articles/03-installing-a-search-engine/01-intro.markdown
@@ -38,10 +38,8 @@ Elasticsearch.
 - [Workflow Metrics](/docs/7-2/user/-/knowledge_base/u/workflow-metrics-the-service-level-agreement) 
 - [Custom Filter search widget](/docs/7-2/user/-/knowledge_base/u/filtering-search-results-with-the-custom-filter-widget)
 - [The Low Level Search Options widget](/docs/7-2/user/-/knowledge_base/u/low-level-search-options-searching-additional-or-alternate-indexes)
-
-<!-- Not yet released
-- Search Tuning: Result Rankings - Confirming with Dennis
-- Search Tuning: Synonyms - Confirming with Dennis-->
+- [Search Tuning: Customizing Search Results](/docs/7-2/deploy/-/knowledge_base/d/search-tuning-customizing-search-results) 
+- [Search Tuning: Synonyms](/docs/7-2/user/-/knowledge_base/u/search-tuning-synonym-sets) 
 
 ### Developer Feature Limitations of Liferay's Solr Integration
 

--- a/en/deployment/articles/03-installing-a-search-engine/03-solr/01-installing-solr-intro.markdown
+++ b/en/deployment/articles/03-installing-a-search-engine/03-solr/01-installing-solr-intro.markdown
@@ -28,3 +28,36 @@ Connector to Solr 7 application.
 
 Liferay Portal CE 7.2, GA2 and later (not available at time of writing), support
 Solr 7.5.x through the Liferay CE Connector to Solr 7 application.
+
+## Blacklisting Elasticsearch-Only Features
+
+Before installing Solr, you must 
+[blacklist](/docs/7-2/user/-/knowledge_base/u/blacklisting-osgi-bundles-and-components) 
+certain DXP 
+[features that only work with Elasticsearch](/docs/7-2/deploy/-/knowledge_base/d/installing-a-search-engine#choosing-a-search-engine). 
+
+1.  Create a configuration file named
+
+    ```sh
+    com.liferay.portal.bundle.blacklist.internal.BundleBlacklistConfiguration.config
+    ```
+
+2.  Give it these contents:
+
+    ```properties
+    blacklistBundleSymbolicNames=["com.liferay.portal.search.tuning.web.api","com.liferay.portal.search.tuning.web","com.liferay.portal.search.tuning.synonyms.web","com.liferay.portal.search.tuning.rankings.web"]
+    ```
+
+3. Place the file in `Liferay Home/osgi/configs`. 
+
+It is required during the Solr installation process to also 
+[stop the Elasticsearch Connectors](https://portal.liferay.dev/docs/7-2/deploy/-/knowledge_base/d/installing-solr-basic-installation#stopping-the-elasticsearch-connector) 
+that ship with @product@. If you're ready to blacklist those bundles now, use
+these contents in the blacklist configuration file:
+
+```properties
+    blacklistBundleSymbolicNames=["com.liferay.portal.search.tuning.web.api","com.liferay.portal.search.tuning.web","com.liferay.portal.search.tuning.synonyms.web","com.liferay.portal.search.tuning.rankings.web","com.liferay.portal.search.elasticsearch6.api","com.liferay.portal.search.elasticsearch6.impl","Liferay Connector to X-Pack Monitoring [Elastic Stack 6.x]","Liferay Connector to X-Pack Security [Elastic Stack 6.x]"]
+```
+
+Community Edition users can exclude the X-Pack bundles, as they are DXP-only
+bundles.


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7272, this PR contains 2 things: 1. Add the search tuning features to the unsupported with Solr list, and 2. Blacklist the search tuning bundles so that they don't blow up the log and incapacitate portal.