### PR TITLE
Search 7.1 | Elasticsearch 6.8 support | LRDOCS-7453

### DIFF
--- a/en/discover/deployment/articles-dxp/02-installing-search-engine/02-enterprise-search/00-intro.markdown
+++ b/en/discover/deployment/articles-dxp/02-installing-search-engine/02-enterprise-search/00-intro.markdown
@@ -7,31 +7,30 @@ header-id: installing-x-pack
 [TOC levels=1-4]
 
 X-Pack is an 
-[Elasticsearch extension](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/setup-xpack.html)
+[Elasticsearch extension](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/setup-xpack.html)
 for securing and monitoring Elasticsearch clusters. If you use Elasticsearch,
 you should secure it with X-Pack. The security features of X-Pack include
 authenticating access to the Elasticsearch cluster's data and encrypting
 Elasticsearch's internal and external communications. These are necessary
 security features for most production systems. A Liferay Enterprise Search
-Premium subscription gets you access to two X-Pack Connectors for @product@:
-monitoring and security. A Liferay Enterprise Search Standard subscription gets
-you the monitoring integration. Contact
+(LES) subscription gets you access to two X-Pack Connectors for @product@:
+monitoring and security. Contact
 [Liferay's Sales department for more information](https://www.liferay.com/contact-us#contact-sales).
 
-Here's an overview of using X-Pack with @product@:
+| **Note:** If you upgrade to @product@ version 7.2, there's an additional LES
+| offering:
+| [Learning to Rank](https://help.liferay.com/hc/en-us/articles/360035444892-Liferay-Enterprise-Search-Learning-to-Rank)
 
-1.  Get an [Enterprise Search subscription](https://help.liferay.com/hc/en-us/articles/360014400932).
+Here's an overview of using LES with @product@:
 
-2.  You'll receive license for X-Pack. Install it on your Elasticsearch servers.
+1.  Get a [LES subscription](https://help.liferay.com/hc/en-us/articles/360014400932).
 
-2.  Download and install the X-Pack connectors you purchased. Access the
-    connector corresponding to your subscription level:
+2.  You'll receive a license for X-Pack. Install it on your Elasticsearch servers.
 
-    [Enterprise Search Standard](https://customer.liferay.com/downloads?p_p_id=com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet&_com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet_productAssetCategoryId=118191015&_com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet_fileTypeAssetCategoryId=118191062)
+2.  [Download](https://customer.liferay.com/downloads)
+    and install the LES apps you purchased.
 
-    [Enterprise Search Premium](https://customer.liferay.com/downloads?p_p_id=com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet&_com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet_productAssetCategoryId=118191013&_com_liferay_osb_customer_downloads_display_web_DownloadsDisplayPortlet_fileTypeAssetCategoryId=118191060)
-
-3.  Configure the connectors with the proper credentials and encryption
+3.  Configure the X-Pack connectors with the proper credentials and encryption
     information.
 
 4.  Restart Elasticsearch. These steps require a full cluster restart.
@@ -45,6 +44,6 @@ Here's an overview of using X-Pack with @product@:
 Following these instructions gives you a working installation of Elasticsearch
 communicating freely with @product@. Elastic's documentation explains additional
 configuration options, features, and the architecture of
-[X-Pack](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/configuring-security.html). 
+[X-Pack](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/configuring-security.html). 
 
 Now you can configure security and/or monitoring, depending on your needs.

--- a/en/discover/deployment/articles-dxp/02-installing-search-engine/02-enterprise-search/01-security/00-security-intro.markdown
+++ b/en/discover/deployment/articles-dxp/02-installing-search-engine/02-enterprise-search/01-security/00-security-intro.markdown
@@ -9,9 +9,11 @@ header-id: installing-liferay-enterprise-search-security
 Once X-Pack is installed, start securing Elasticsearch by configuring the
 built-in user passwords.
 
+First, make sure security is enabled on Elasticsearch.
+
 ## Enabling X-Pack Security
 
-The first thing to do is enable X-Pack security. Add this setting in
+To enable X-Pack security on Elasticsearch, add this setting to
 `elasticsearch.yml`:
 
     xpack.security.enabled: true
@@ -27,11 +29,11 @@ X-Pack users are important:
 - `elastic`
 
 Set the passwords for all X-Pack's 
-[built-in users](https://www.elastic.co/guide/en/x-pack/6.5/setting-up-authentication.html#built-in-users).
+[built-in users](https://www.elastic.co/guide/en/x-pack/6.8/setting-up-authentication.html#built-in-users).
 The `setup-passwords` command is the simplest method to set the built-in users'
 first-use passwords for the first time. To update a password subsequently, use
 Kibana's UI or the 
-[Change Password API](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/security-api-change-password.html).
+[Change Password API](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/security-api-change-password.html).
 
 The `interactive` argument sets the passwords for all built-in users. The
 configuration shown in these articles assumes you set all passwords to
@@ -39,9 +41,9 @@ configuration shown in these articles assumes you set all passwords to
 
     ./bin/elasticsearch-setup-passwords interactive
 
-Elastic's 
-[setup-passwords command](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/setup-passwords.html) 
-documentation describes additional options.
+See the Elasticsearch 
+[setup-passwords command](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/setup-passwords.html) 
+documentation for additional options.
 
 Since you're securing Elasticsearch, remember the `elastic` user's password. 
 
@@ -58,12 +60,12 @@ whenever one is needed. Use your own passwords for your installation.
 
 ### Generate Node Certificates
 
-[Generate a node certificate](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/configuring-tls.html#node-certificates)
+[Generate a node certificate](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/configuring-tls.html#node-certificates)
 for each node. You can, of course, use a Certificate Authority to obtain node 
 certificates.
 
 1.  Create a certificate authority, using 
-    [X-Pack's `certutil`](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/certutil.html)
+    [X-Pack's `certutil`](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/certutil.html)
     command:
 
         ./bin/elasticsearch-certutil ca --pem --ca-dn CN=localhost
@@ -84,7 +86,7 @@ certificates.
 
 ### Enable TLS
 
-[Enable TLS](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/configuring-tls.html#enable-ssl) 
+[Enable TLS](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/configuring-tls.html#enable-ssl) 
 on each node via its `elasticsearch.yml`.
 
 1.  Add the certificate, key and certificate authority paths to each node's
@@ -171,3 +173,29 @@ Here's the complete list of configuration options for the X-Pack Connector:
 
 When you're finished configuring X-Pack Security, restart Elasticsearch. These
 steps require a full cluster restart.
+
+### Disabling Elasticsearch Deprecation Logging
+
+Some Elasticsearch APIs used by Liferay's Elasticsearch 6 connector were
+deprecated as of Elasticsearch 6.6 and 6.7. This can result WARN log entries in
+Elasticsearch's deprecation log when @product@ is configured with Elasticsearch
+6.8.x and X-Pack Security is enabled:
+
+```sh
+2019-07-16T14:47:05,779][WARN ][o.e.d.c.j.Joda           ] [
+ode_name]'y' year should be replaced with 'u'. Use 'y' for year-of-era. Prefix your date format with '8' to use the new specifier.
+[2019-07-16T14:47:06,007][WARN ][o.e.d.c.s.Settings       ] [
+ode_name][xpack.ssl.certificate] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
+[2019-07-16T14:47:06,007][WARN ][o.e.d.c.s.Settings       ] [
+ode_name][xpack.ssl.certificate_authorities] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
+[2019-07-16T14:47:06,008][WARN ][o.e.d.c.s.Settings       ] [
+ode_name][xpack.ssl.key] setting was deprecated in Elasticsearch and will be removed in a future release! See the breaking changes documentation for the next major version.
+[2019-07-16T14:47:06,463][WARN ][o.e.d.x.c.s.SSLService   ] [
+ode_name]SSL configuration [xpack.http.ssl] relies upon fallback to another configuration for [key configuration, trust configuration], which is deprecated.
+[2019-07-16T14:47:06,464][WARN ][o.e.d.x.c.s.SSLService   ] [
+ode_name]SSL configuration [xpack.security.transport.ssl.] relies upon fallback to another configuration for [key configuration, trust configuration], which is deprecated.
+```
+
+These warnings do not signal any functional issues, and can be disabled (see
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/logging.html#deprecation-logging)
+to learn how).

--- a/en/discover/deployment/articles-dxp/02-installing-search-engine/02-enterprise-search/02-monitoring/00-monitoring-intro.markdown
+++ b/en/discover/deployment/articles-dxp/02-installing-search-engine/02-enterprise-search/02-monitoring/00-monitoring-intro.markdown
@@ -10,11 +10,13 @@ Monitor Elasticsearch with X-Pack Monitoring. First
 [install X-Pack onto Elasticsearch](discover/deployment/-/knowledge_base-7-1/installing-x-pack)
 and configure security if you're using X-Pack's security features. Then come
 back here for instructions on installing and configuring Kibana (the monitoring
-server) with X-Pack so that Elasticsearch (secured with X-Pack), Kibana (secured
-with X-Pack), and @product@ can communicate effortlessly and securely. A Liferay
-Enterprise Search Standard subscription (included with Premium) is necessary for
-this integration.  Contact 
+server) with X-Pack so that Elasticsearch (secured with X-Pack), Kibana
+(secured with X-Pack), and @product@ can communicate effortlessly and securely.
+A Liferay Enterprise Search (LES) subscription is necessary for this
+integration.  Contact 
 [Liferay's Sales department for more information](https://www.liferay.com/contact-us#contact-sales).
+
+Here's the generalized procedure:
 
 1.  Tell Elasticsearch to enable data collection.
 
@@ -53,7 +55,13 @@ for details.
 2.  Tell Kibana where to send monitoring data by setting Elasticsearch's URL in
     `kibana.yml`:
 
+    On Elasticsearch 6.1 and 6.5 the property was 
+
         elasticsearch.url: "http://localhost:9200"
+
+    On Elasticsearch 6.8 and above, use 
+
+        elasticsearch.hosts: [ "http://localhost:9200" ]
 
     If SSL is enabled on Elasticsearch, this is an `https` URL.
 
@@ -69,7 +77,7 @@ additional configuration required before starting Kibana.
 
 If X-Pack requires authentication to access the Elasticsearch cluster, follow
 these steps or refer to 
-[Elastic's documentation](https://www.elastic.co/guide/en/kibana/6.5/monitoring-xpack-kibana.html). 
+[Elastic's documentation](https://www.elastic.co/guide/en/kibana/6.8/monitoring-xpack-kibana.html). 
 
 1.  Set the password for the built-in `kibana` user in `[Kibana
     Home]/config/kibana.yml`:
@@ -87,16 +95,16 @@ these steps or refer to
         ./bin/kibana
 
 3.  Go to `localhost:5601` and make sure you can sign in as a 
-    [user](https://www.elastic.co/guide/en/x-pack/6.5/native-realm.html#native-add)
+    [user](https://www.elastic.co/guide/en/x-pack/6.8/native-realm.html#native-add)
     who has the `kibana_user` 
-    [role](https://www.elastic.co/guide/en/x-pack/6.5/built-in-roles.html) 
+    [role](https://www.elastic.co/guide/en/x-pack/6.8/built-in-roles.html) 
     or a superuser (like the `elastic` user).
 
 ### Configuring Kibana with Encryption
 
 Follow these steps to configure Kibana if X-Pack encrypts communication with the
 Elasticsearch cluster. Consult 
-[Elastic's guide](https://www.elastic.co/guide/en/kibana/6.5/using-kibana-with-security.html#using-kibana-with-security)
+[Elastic's guide](https://www.elastic.co/guide/en/kibana/6.8/using-kibana-with-security.html#using-kibana-with-security)
 for more information.
 
 Add these settings to `kibana.yml`:
@@ -114,7 +122,7 @@ Add these settings to `kibana.yml`:
 
 For more information about monitoring and security best practices in a clustered
 environment, refer to 
-[Elastic's documentation](https://www.elastic.co/guide/en/x-pack/6.5/secure-monitoring.html).
+[Elastic's documentation](https://www.elastic.co/guide/en/x-pack/6.8/secure-monitoring.html).
 
 After this step you can access Kibana at `https://localhost:5601` and sign in
 with a Kibana user. The last step is to connect Kibana to @product@.
@@ -200,4 +208,4 @@ servers are running, add the X-Pack Monitoring portlet to a page:
     the Search category onto the page.
 
 See the Elastic documentation for information on 
-[monitoring Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/es-monitoring.html).
+[monitoring Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/es-monitoring.html).

--- a/en/discover/deployment/articles/01-deploying-liferay/10-installing-elasticsearch.markdown
+++ b/en/discover/deployment/articles/01-deploying-liferay/10-installing-elasticsearch.markdown
@@ -46,7 +46,7 @@ Installing Elasticsearch is pretty easy and takes only six steps:
 | using the same version and distribution (e.g., Oracle Open JDK 1.8.0_201). You can
 | specify this in `[Elasticsearch Home]/bin/elasticsearch.in.sh`:
 | 
-|         JAVA_HOME=/path/to/java
+| `JAVA_HOME=/path/to/java`
 | 
 | Consult the
 | [Elasticsearch compatibility matrix](https://www.elastic.co/support/matrix#matrix_jvm)
@@ -91,6 +91,9 @@ A JSON document is returned that looks similar to this:
 
 The version of Elasticsearch that's running is the value of the `"number"` field.
 In this example, it's 6.5.1. 
+
+| **Note:** Although the embedded server uses Elasticsearch 6.5, Elasticsearch
+| 6.8.x has been tested with @product-ver@, and is fully supported.
 
 Shut down the @product@ server. In a local, single-machine testing environment,
 if you continue without shutting down, the Elasticsearch server you're about to
@@ -165,6 +168,10 @@ Elasticsearch starts, and one of its status messages includes a transport addres
 Take note of this address; you'll need to give it to your @product@ server so it
 can find Elasticsearch on the network. 
 
+| **X-Pack Security:** You must also disable X-Pack  Security unless you have a
+| Liferay Enterprise Search subscription and are installing security at the same
+| time. To disbale it, add this to `elasticsearch.yml`: `xpack.security.enabled:false`.
+
 ### Step Five: Configure @product@ to Connect to your Elasticsearch Cluster
 
 Now that you're ready to configure @product@, start it if you haven't already,
@@ -193,5 +200,5 @@ and click on *Control Panel* &rarr; *Configuration* &rarr; *Search* and
 click the *Execute* button for *Reindex all search indexes*. When you do that,
 you should see some messages scroll up in the Elasticsearch log. 
 
-For more details refer to the [Elasticsearch installation guide](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/_installation.html).
+For more details refer to the [Elasticsearch installation guide](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/install-elasticsearch.html).
 

--- a/en/discover/deployment/articles/02-installing-search-engine/00-intro.markdown
+++ b/en/discover/deployment/articles/02-installing-search-engine/00-intro.markdown
@@ -42,6 +42,63 @@ If you must use either of those features in your search solution's code, use
 Elasticsearch. If you're using @commerce@, use Elasticsearch.
 Otherwise, feel free to use Elasticsearch or Solr to index your portal content.
 
+<!-- copied wholesale ffrom the 7.2 article. need to curate for 7.1 -->
+
+## Choosing a Search Engine
+
+Elasticsearch and Solr are both supported, but there are limitations to
+Liferay's Solr integration. To make use of some features, you must choose
+Elasticsearch. 
+
+### End User Feature Limitations of Liferay's Solr Integration
+
+- [Liferay Commerce](https://help.liferay.com/hc/en-us/articles/360017869952)
+- [Workflow Metrics](https://help.liferay.com/hc/en-us/articles/360029042071-Workflow-Metrics-The-Service-Level-Agreement-SLA-) 
+- [Custom Filter search widget](/docs/7-2/user/-/knowledge_base/u/filtering-search-results-with-the-custom-filter-widget)
+- [The Low Level Search Options widget](/docs/7-2/user/-/knowledge_base/u/low-level-search-options-searching-additional-or-alternate-indexes)
+- [Search Tuning: Customizing Search Results](https://help.liferay.com/hc/en-us/articles/360034473872-Search-Tuning-Customizing-Search-Results) 
+- [Search Tuning: Synonyms](https://help.liferay.com/hc/en-us/articles/360034473852-Search-Tuning-Synonym-Sets) 
+
+### Developer Feature Limitations of Liferay's Solr Integration
+
+Implementation for the following APIs may be added in the future, but they are
+not currently supported by Liferay's Solr connector.
+
+- From Portal Core (Module: `portal-kernel`, Artifact:
+    `com.liferay.portal.kernel`):
+    - `com.liferay.portal.kernel.search.generic.NestedQuery`
+    - `com.liferay.portal.kernel.search.filter`:
+        - `ComplexQueryPart`
+        - `GeoBoundingBoxFilter`
+        - `GeoDistanceFilter`
+        - `GeoDistanceRangeFilter`
+        - `GeoPolygonFilter`
+- From the Portal Search API (Module: `portal-search-api`, Artifact:
+    `com.liferay.portal.search.api`):
+    - `com.liferay.portal.search.filter`:
+        - `ComplexQueryPart`
+        - `TermsSetFilter`
+    - `com.liferay.portal.search.geolocation.*`
+    - `com.liferay.portal.search.highlight.*`
+    - `com.liferay.portal.search.query.function.*`
+    - `com.liferay.portal.search.query.*`:
+    - `com.liferay.portal.search.script.*`
+    - `com.liferay.portal.search.significance.*`
+    - `com.liferay.portal.search.sort.*`: only `Sort`,`FieldSort`, and
+        `ScoreSort` are supported
+- Portal Search Engine Adapter API (Module: `portal-search-engine-adapter-api`,
+    Artifact: `com.liferay.portal.search.engine.adapter.api`)
+    - `com.liferay.portal.search.engine.adapter.cluster.*`
+    - `com.liferay.portal.search.engine.adapter.document.UpdateByQueryDocumentRequest`
+    - `com.liferay.portal.search.engine.adapter.index.*`: only `RefreshIndexRequest` is supported
+    - `com.liferay.portal.search.engine.adapter.search.*`: 
+        - `MultisearchSearchRequest` 
+        - `SuggestSearchRequest`
+    - `com.liferay.portal.search.engine.adapter.snapshot.*`
+
+Liferay Commerce requires the `TermsSetFilter` implementation, only available
+in the Elasticsearch connector.
+
 Another factor to consider in your search engine selection is JDK version. The
 search engine and @product@ must use the same JDK version and distribution
 (e.g., Oracle Open JDK 1.8.0_201). Consult the 

--- a/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/00-intro.markdown
+++ b/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/00-intro.markdown
@@ -32,7 +32,7 @@ developer tutorial Introduction to Liferay Search (not yet written).
 These terms are useful to understand as you read this guide:
 
 -  *Elasticsearch Home* refers to the root folder of your unzipped Elasticsearch
-   installation (for example, `elasticsearch-6.5.1`). 
+   installation (for example, `elasticsearch-6.8.4`). 
 
 -  [*Liferay Home*](/docs/7-1/deploy/-/knowledge_base/d/installing-liferay#liferay-home)
    refers to the root folder of your @product@ installation. It contains the

--- a/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/02-configuring-the-connector.markdown
+++ b/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/02-configuring-the-connector.markdown
@@ -7,7 +7,7 @@ header-id: configuring-the-liferay-elasticsearch-connector
 [TOC levels=1-4]
 
 For detailed Elasticsearch configuration information, refer to the
-[Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/settings.html).
+[Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/settings.html).
 
 The name of your Elasticsearch cluster is important. When you're running
 Elasticsearch in remote mode, the cluster name is used by @product@ to recognize
@@ -133,17 +133,11 @@ file:
 As you can see from the System Settings entry for Elasticsearch, there are a lot
 more configuration options available that help you tune your system for optimal
 performance. 
-<!-- For a detailed accounting of these, refer to the reference article
-on [Elasticsearch Settings](discover/reference/-/knowledge_base/7-1/elasticsearch-settings).
--->
 
 What follows here are some known good configurations for clustering
 Elasticsearch. These, however, can't replace the manual process of tuning,
 testing under load, and tuning again, so we encourage you to examine the
-<!--
-[settings](discover/reference/-/knowledge_base/7-1/elasticsearch-settings) 
-as well as the -->
-[Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/important-settings.html) 
+[Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/important-settings.html) 
 and go through that process once you have a working configuration. 
 
 ## Configuring a Remote Elasticsearch Host
@@ -173,7 +167,7 @@ On the Elasticsearch side, set the `network.host` property in your
 (the host where Elasticsearch listens for requests) and the *publish host*
 (the host name or IP address Elasticsearch uses to communicate with other
 nodes). See
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-network.html)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-network.html)
 for more information.
 
 ## Clustering Elasticsearch in Remote Operation Mode
@@ -182,7 +176,7 @@ Clustering Elasticsearch is easy. First, set `node.max_local_storage_nodes` to
 be something greater than `1`. When you run the Elasticsearch start script,
 a new local storage node is added to the cluster. If you want four nodes running
 locally, for example, run `./bin/elasticsearch` four times. See
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-node.html#max-local-storage-nodes)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-node.html#max-local-storage-nodes)
 for more information.
 
 Configure the number of shards and replicas in the Elasticsearch 6 adapter,
@@ -193,14 +187,13 @@ since the default number of shards is `5` and the default number of replica
 shards is `1`.
 
 | **Note:** Elasticsearch uses the
-| [Zen Discovery Module](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-discovery-zen.html)
+| [Zen Discovery Module](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-discovery-zen.html)
 | by default, which provides unicast discovery. Additionally, nodes in the cluster
 | communicate using the
-| [Transport Module](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-transport.html),
+| [Transport Module](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-transport.html),
 | through TCP. See the Elasticsearch documentation for the available properties
 | (to be set in the `elasticsearch.yml` file), and the @product@ Elasticsearch
 | Adapter's settings for the adapter's available settings.
-| <!--reference article](discover/reference/-/knowledge_base/7-1/elasticsearch-settings)-->
 | 
 | At a minimum, provide the list of hosts (as `host:port`)  to act as gossip
 | routers during unicast discovery in the `elasticsearch.yml`:

--- a/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/03-advanced-configuration.markdown
+++ b/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/03-advanced-configuration.markdown
@@ -33,7 +33,7 @@ The `additionalConfigurations` configuration defines extra settings (in YAML)
 for the embedded Elasticsearch. This is only useful for testing environments
 using the embedded Elasticsearch server. Any node settings normally set in
 `elasticsearch.yml` can be declared here. See the
-[Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/index.html) 
+[Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/index.html) 
 for a description of all possible node settings.
 
 ### Adding Index Configurations
@@ -42,7 +42,7 @@ The `additionalIndexConfigurations` configuration defines extra settings (in
 JSON or YAML) that are applied to the @product@ index when it's created. For
 example, you can create custom analyzers and filters using this setting. For a
 complete list of available settings, see the 
-[Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/index-modules.html).
+[Elasticsearch reference](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/index-modules.html).
 
 Here's an example that shows how to configure 
 [analysis](https://www.elastic.co/guide/en/elasticsearch/guide/current/analysis-intro.html#analysis-intro)
@@ -75,9 +75,9 @@ template).
 `additionalTypeMappings` defines extra mappings for the `LiferayDocumentType`
 type definition. These are applied when the index is created. Add the mappings
 in using JSON syntax. For more information see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/mapping.html)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/mapping.html)
 and
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/indices-put-mapping.html).
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-put-mapping.html).
 Use `additionalTypeMappings` for new field (`properties`) mappings and new
 dynamic templates, but don't try to override existing mappings. If any of the
 mappings set here overlap with existing mappings, index creation fails. Use
@@ -85,7 +85,7 @@ mappings set here overlap with existing mappings, index creation fails. Use
 
 As with dynamic templates, you can
 add sub-field mappings to @product@'s type mapping. These are referred to as
-[properties](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/properties.html)
+[properties](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/properties.html)
 in Elasticsearch.
 
     { 
@@ -101,7 +101,7 @@ in Elasticsearch.
     }
 
 See
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/mapping-types.html)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/mapping-types.html)
 for more details on Elasticsearch's field datatypes.
 
 The above example shows how a `fooName` field might be added to @product@'s type
@@ -154,7 +154,7 @@ Now modify whatever mappings you'd like. The changes take effect once you save
 the changes and trigger a re-index from Server Administration. 
 
 Here's a partial example, showing a 
-[dynamic template](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/dynamic-templates.html)
+[dynamic template](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/dynamic-templates.html)
 that uses the analysis configuration from `additionalIndexConfigurations` to
 analyze all string fields that end with `_ja`. You'd include this with all the
 other default mappings, replacing the provided `template_ja` with this custom

--- a/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/04-elasticsearch-connector-settings-reference.markdown
+++ b/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/04-elasticsearch-connector-settings-reference.markdown
@@ -46,7 +46,7 @@ effect.
 `bootstrapMlockAll=false`
 : A boolean setting that, when set to `true`, tries to lock the process address
 space into RAM, preventing any Elasticsearch memory from being swapped out (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/setup-configuration-memory.html#bootstrap-memory_lock))
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/setup-configuration-memory.html#bootstrap-memory_lock))
 for more information)
 
 `logExceptionsOnly=true`
@@ -56,56 +56,56 @@ Elasticsearch, and does not rethrow them.
 `retryOnConflict=5`
 : Set an int value for the number of retries to attempt if a version conflict
 occurs because the document was updated between getting it and updating it (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/docs-update.html#_parameters_3)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-update.html#_parameters_3)
 for more information).
 
 `discoveryZenPingUnicastHostsPort=9300-9400`
 : Set a String value for the range of ports to use when building the value for
 discovery.zen.ping.unicast.hosts. Multiple Elasticsearch nodes on a range of
 ports can act as gossip routers at the same computer (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-discovery-zen.html)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-discovery-zen.html)
 for more information).
 
 `networkHost=`
 : Set this String value to instruct the node to bind to this hostname or IP
 address and publish (advertise) this host to other nodes in the cluster. This is
 a shortcut which sets the bind host and the publish host at the same time (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-network.html#common-network-settings)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-network.html#common-network-settings)
 for more information).
 
 `networkBindHost=`
 : Set the String value of the network interface(s) a node should bind to in order
 to listen for incoming requests (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-network.html#advanced-network-settings)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-network.html#advanced-network-settings)
 for more information).
 
 `networkPublishHost=`
 : Set the String value of a single interface that the node advertises to other
 nodes in the cluster, so that those nodes can connect to it (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-network.html#advanced-network-settings)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-network.html#advanced-network-settings)
 for more information).
 
 `transportTcpPort=`
 : Set the String value for the port to bind for communication between nodes.
 Accepts a single value or a range
-(see [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-transport.html#_tcp_transport)
+(see [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-transport.html#_tcp_transport)
 for more information).
 
 `transportAddresses=localhost:9300`
 : Set the String values for the addresses of the remote Elasticsearch nodes to
 connect to. This value is required when Operation Mode is set to remote (see
-[here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/transport-client.html)
+[here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.8/transport-client.html)
 for more information). Specify as many or few nodes as you see fit.
 
 `clientTransportSniff=true`
 : Set this booleant to true to enable cluster sniffing and dynamically discover
 available data nodes in the cluster
-(see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/transport-client.html)
+(see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.8/transport-client.html)
 for more information).
 
 `clientTransportIgnoreClusterName=false`
 : Set this boolean to true to ignore cluster name validation of connected nodes
-(see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/transport-client.html)
+(see [here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.8/transport-client.html)
 for more information).
 
 `clientTransportPingTimeout=`
@@ -115,30 +115,30 @@ unset, the default Elasticsearch `client.transport.ping_timeout` is used.
 `clientTransportNodesSamplerInterval=`
 : Set this String value to instruct the client node on how often to sample / ping
 the nodes listed and connected (see
-[here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.5/transport-client.html)
+[here](https://www.elastic.co/guide/en/elasticsearch/client/java-api/6.8/transport-client.html)
 for more information).
 
 `httpEnabled=true`
 : Set this boolean to false to disable the http layer entirely on nodes which are
 not meant to serve REST requests directly. As this setting was 
-[deprecated in Elasticsearch 6.3](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-6.3.0.html#deprecation-6.3.0), the connector's corresponding setting is now also deprecated. This setting was only used for configuring the embedded Elasticsearch server, so its deprecation should have minimal impact to production deployments.
+[deprecated in Elasticsearch 6.3](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/release-notes-6.3.0.html#deprecation-6.3.0), the connector's corresponding setting is now also deprecated. This setting was only used for configuring the embedded Elasticsearch server, so its deprecation should have minimal impact to production deployments.
 
 `httpCORSEnabled=true`
 : Set this boolean to false to disable cross-origin resource sharing, i.e. whether
 a browser on another origin can do requests to Elasticsearch. If disabled, web
 front end tools like elasticsearch-head may be unable to connect (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-http.html#_settings_2)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-http.html#_settings_2)
 for more information).
 
 `httpCORSAllowOrigin=/https?:\\/\\/localhost(:[0-9]+)?/`
 : Set the String origins to allow when HTTP CORS is enabled (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-http.html#_settings_2)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-http.html#_settings_2)
 for more information).
 
 `httpCORSConfigurations=`
 : Set the String values for custom settings for HTTP CORS, in YML format
 (elasticsearch.yml) (see
-[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-http.html#_settings_2)
+[here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-http.html#_settings_2)
 for more information).
 
 `additionalConfigurations=`
@@ -187,5 +187,5 @@ remote Elasticsearch installations:
 - `httpCORSConfigurations` 
 - `syncSearch`
 
-You can easily configure these settings in the System Setting application, or
-as mentioned above, you can specify them in a deployable OSGi `.config` file.
+Configure these settings in the System Setting application, or as mentioned
+above, you can specify them in a deployable OSGi `.config` file.

--- a/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/06-backing-up-es.markdown
+++ b/en/discover/deployment/articles/02-installing-search-engine/01-elasticsearch/06-backing-up-es.markdown
@@ -21,11 +21,11 @@ Back up and restore your Elasticsearch cluster in three steps:
 For more detailed information, refer to the 
 [Elasticsearch administration guide](https://www.elastic.co/guide/en/elasticsearch/guide/master/administration.html),
 and in particular to the documentation on the 
-[Snapshot/Restore module](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-snapshots.html).
+[Snapshot/Restore module](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-snapshots.html).
 
 ## Creating a Repository
 
-First [create a repository](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-snapshots.html#_repositories)
+First [create a repository](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-snapshots.html#_repositories)
 to store your snapshots. Several repository types are supported:
 
 - Shared file system, such as a Network File System or NAS
@@ -35,7 +35,7 @@ to store your snapshots. Several repository types are supported:
 
 If using a shared file system repository type, first register the path to the
 shared file system in each node's `elasticsearch.yml` using 
-[the path.repo setting](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-snapshots.html#_shared_file_system_repository).
+[the path.repo setting](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-snapshots.html#_shared_file_system_repository).
 
     path.repo: ["path/to/shared/file/system/"]
 
@@ -63,7 +63,7 @@ Once the repository exists, you can start creating snapshots.
 ## Taking Snapshots of the Cluster
 
 The easiest snapshot approach is to create a 
-[snapshot of all the indexes in your cluster](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-snapshots.html#_snapshot). 
+[snapshot of all the indexes in your cluster](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-snapshots.html#_snapshot). 
 To snapshot everything, enter
 
     curl -XPUT localhost:9200/_snapshot/test_backup/snapshot_1
@@ -141,7 +141,7 @@ terminated and the partial snapshot is deleted from the repository.
 ## Restoring from a Snapshot
 
 What good is a snapshot if you can't use it to 
-[restore your search indexes](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-snapshots.html#_restore) 
+[restore your search indexes](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-snapshots.html#_restore) 
 in case of catastrophic failure? Use the `_restore` API to restore all the
 snapshot's indexes:
 
@@ -173,4 +173,4 @@ Nobody likes catastrophic failure on a production system, but Elasticsearch's
 API for taking snapshots and restoring indexes can help you rest easy knowing
 that your search cluster can be restored if disaster strikes. For more details
 and options, read Elastic's documentation on the [Snapshot and Restore
-Module](https://www.elastic.co/guide/en/elasticsearch/reference/6.5/modules-snapshots.html#modules-snapshots).
+Module](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-snapshots.html#modules-snapshots).


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-7453, this tries to get us up to 6.8 for Liferay 7.1. The section on Choosing a Search Engine needs help, as I mentioned in the ticket. Let me know if you think anything else is needed.